### PR TITLE
Remove `has_rdoc` from gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,10 @@ GEM
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
     rdoc (4.3.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rest-client (2.0.2-x64-mingw32)
       ffi (~> 1.9)
       http-cookie (>= 1.0.2, < 2.0)
@@ -98,6 +102,7 @@ GEM
     thor (0.20.0)
     unf (0.1.4)
       unf_ext
+    unf_ext (0.0.7.5)
     unf_ext (0.0.7.5-x64-mingw32)
     unicode-display_width (1.3.0)
 
@@ -119,4 +124,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/azurekeyvault.gemspec
+++ b/azurekeyvault.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.homepage  = 'https://github.com/MikeAScott/azure-key-vault'
   s.email     = 'mike.scott2@hiscox.com'
   s.authors   = ['Mike Scott']
-  s.has_rdoc  = false
   s.license   = 'MIT'
 
   s.files = (%x[git ls-files]).split($RS) - %w[.gitignore]


### PR DESCRIPTION
When I ran `bundle install` I got the warning:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```

This comes from the line `s.has_rdoc  = false` in the gemspec file. This PR removes this deprecated feature.

I have also updated `Gemfile.lock` as it appears to be missing the non-Windows version of `rest-client` and `unf-ext`.