### PR TITLE
Stub unf_ext gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     shellany (0.0.1)
     thor (0.20.0)
     unf (0.1.4)
-      unf_ext
+      unf_ext (0.0.7.5-x64-mingw32)
     unf_ext (0.0.7.5-x64-mingw32)
     unicode-display_width (1.3.0)
 


### PR DESCRIPTION
We should stub unf_ext gem because bundle try to install latest version of it (0.0.7.6).
With latest GCC compilers we have more strict rules and unf_ext 0.0.7.6 can't be installed -

===================================================
=============ERROR==BACKTRACE======================
$ bundle install
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies....
Using concurrent-ruby 1.1.5
Using i18n 1.7.0
Using minitest 5.13.0
Using thread_safe 0.3.6
Using tzinfo 1.2.5
Using zeitwerk 2.2.2
Using activesupport 6.0.1
Using public_suffix 4.0.1
Using addressable 2.7.0
Using application_insights 0.5.6
Using ast 2.4.0
Using multipart-post 2.1.1
Using faraday 0.17.0
Using faraday_middleware 0.13.1
Using mini_portile2 2.4.0
Using nokogiri 1.10.4
Using azure-core 0.1.15
Using mime-types-data 3.2019.1009
Using mime-types 3.3
Using systemu 2.6.5
Using thor 0.20.3
Using azure 0.7.10
Using json_pure 2.2.0
Using http-accept 1.7.0
Fetching unf_ext 0.0.7.6
Installing unf_ext 0.0.7.6 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/usr/local/sce/etc/ruby/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.6/ext/unf_ext
/usr/local/sce/bin/ruby -I /usr/local/sce/etc/ruby/lib/ruby/2.6.0 -r
./siteconf20200320-21644-17igl99.rb extconf.rb
checking for -lstdc++... yes
creating Makefile

current directory:
/usr/local/sce/etc/ruby/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.6/ext/unf_ext
make "DESTDIR=" clean

current directory:
/usr/local/sce/etc/ruby/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.6/ext/unf_ext
make "DESTDIR="
compiling unf.cc
cc1plus: warning: command line option ‘-Wdeclaration-after-statement’ is valid
for C/ObjC but not for C++
cc1plus: warning: command line option ‘-Wimplicit-function-declaration’ is valid
for C/ObjC but not for C++
cc1plus: warning: command line option ‘-Wimplicit-int’ is valid for C/ObjC but
not for C++
In file included from /usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby.h:33,
                 from unf.cc:3:
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/ruby.h:118:73: error: narrowing
conversion of ‘-1’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
118 | typedef char ruby_check_sizeof_long[SIZEOF_LONG == sizeof(long) ? 1 :
-1];
|
^
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/ruby.h:118:65: error: size ‘-1’
of array ‘ruby_check_sizeof_long’ is negative
118 | typedef char ruby_check_sizeof_long[SIZEOF_LONG == sizeof(long) ? 1 :
-1];
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/ruby.h:122:76: error: narrowing
conversion of ‘-1’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
122 | typedef char ruby_check_sizeof_voidp[SIZEOF_VOIDP == sizeof(void*) ? 1 :
-1];
|
^
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/ruby.h:122:68: error: size ‘-1’
of array ‘ruby_check_sizeof_voidp’ is negative
122 | typedef char ruby_check_sizeof_voidp[SIZEOF_VOIDP == sizeof(void*) ? 1 :
-1];
In file included from
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/intern.h:35,
from
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/ruby.h:2111,
                 from /usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby.h:33,
                 from unf.cc:3:
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/st.h:58:93: error: narrowing
conversion of ‘-1’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
58 | typedef char st_check_for_sizeof_st_index_t[SIZEOF_VOIDP ==
(int)sizeof(st_index_t) ? 1 : -1];
|
^
/usr/local/sce/etc/ruby/include/ruby-2.6.0/ruby/st.h:58:85: error: size ‘-1’ of
array ‘st_check_for_sizeof_st_index_t’ is negative
58 | typedef char st_check_for_sizeof_st_index_t[SIZEOF_VOIDP ==
(int)sizeof(st_index_t) ? 1 : -1];
cc1plus: warning: unrecognized command line option ‘-Wno-self-assign’
cc1plus: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1plus: warning: unrecognized command line option
‘-Wno-constant-logical-operand’
cc1plus: warning: unrecognized command line option ‘-Wno-self-assign’
cc1plus: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1plus: warning: unrecognized command line option
‘-Wno-constant-logical-operand’
make: *** [Makefile:213: unf.o] Error 1

make failed, exit code 2

Gem files will remain installed in
/usr/local/sce/etc/ruby/lib/ruby/gems/2.6.0/gems/unf_ext-0.0.7.6 for inspection.
Results logged to
/usr/local/sce/etc/ruby/lib/ruby/gems/2.6.0/extensions/sparc-solaris-2.11/2.6.0/unf_ext-0.0.7.6/gem_make.out

An error occurred while installing unf_ext (0.0.7.6), and Bundler
cannot continue.
Make sure that `gem install unf_ext -v '0.0.7.6' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  azure-key-vault was resolved to 0.0.16, which depends on
    rest-client was resolved to 2.1.0, which depends on
      http-cookie was resolved to 1.0.3, which depends on
        domain_name was resolved to 0.5.20190701, which depends on
          unf was resolved to 0.1.4, which depends on
            unf_ext